### PR TITLE
Don't log stacktraces to warn.

### DIFF
--- a/src/main/java/de/tk/opensource/privacyproxy/routing/RoutingHandler.java
+++ b/src/main/java/de/tk/opensource/privacyproxy/routing/RoutingHandler.java
@@ -97,12 +97,19 @@ public abstract class RoutingHandler {
         } catch (HttpStatusCodeException e) {
             logger.warn(
                     String.format(EXCEPTION_PROXY_MESSAGE, targetEndpoint, e.getMessage())
+                            + ", with status code: " + e.getStatusCode()
+            );
+            logger.debug(
+                    String.format(EXCEPTION_PROXY_MESSAGE, targetEndpoint, e.getMessage())
                             + ", with status code: " + e.getStatusCode(),
                     e
             );
             return ResponseEntity.status(HttpStatus.GATEWAY_TIMEOUT).build();
         } catch (IOException ee) {
             logger.warn(
+                    String.format(EXCEPTION_PROXY_MESSAGE, targetEndpoint, ee.getMessage())
+            );
+            logger.debug(
                     String.format(EXCEPTION_PROXY_MESSAGE, targetEndpoint, ee.getMessage()),
                     ee
             );


### PR DESCRIPTION
Basic log message already contains enough information to understand what is going on. 

However, continue to log them to debug so we can have access to them if we need them.
